### PR TITLE
Fix arc drawing in polygons

### DIFF
--- a/examples/example.cpp
+++ b/examples/example.cpp
@@ -24,6 +24,7 @@
 #include <iostream>
 #include <cairo.h>
 #include <QFlags>
+#include <QtMath>
 
 const double scaleFactor = 25.4 / 0.01; //One pixel is 0.01mm
 const double border = 50; //50mm border
@@ -42,8 +43,8 @@ int main(int argc, char** argv) {
 	//gInfo->polarity = GERBV_POLARITY_NEGATIVE;
 
 	//Compute the image size
-	int size_x = ceil((gInfo->max_x - gInfo->min_x)*scaleFactor)+border*2;
-	int size_y = ceil((gInfo->max_y - gInfo->min_y)*scaleFactor)+border*2;
+	int size_x = qCeil((gInfo->max_x - gInfo->min_x)*scaleFactor)+border*2;
+	int size_y = qCeil((gInfo->max_y - gInfo->min_y)*scaleFactor)+border*2;
 
 	//Compute the render info
 	gerbv_render_info_t RenderInfo;

--- a/gerbvQt/gerbvQt.cpp
+++ b/gerbvQt/gerbvQt.cpp
@@ -334,7 +334,6 @@ void gerbvQt::drawLineRect(QPointF& start, QPointF& stop, const gerbv_aperture_t
 }
 
 void gerbvQt::generateArcPath(QPainterPath& path, const gerbv_net_t* cNet) {
-	double sign = (cNet->interpolation == GERBV_INTERPOLATION_CW_CIRCULAR ? 1:-1);
 	double ang1 = cNet->cirseg->angle1;
 	double ang2 = cNet->cirseg->angle2;
 	
@@ -342,8 +341,9 @@ void gerbvQt::generateArcPath(QPainterPath& path, const gerbv_net_t* cNet) {
 	topleft -= QPointF(fabs(cNet->cirseg->width)/2.0, fabs(cNet->cirseg->height) / 2.0);
 	QRectF arcRect(topleft, QSizeF(cNet->cirseg->width, cNet->cirseg->height));
 	
-	path.arcMoveTo(arcRect, sign*ang1);
-	path.arcTo(arcRect, sign*ang1, sign*fabs(ang2-ang1));
+	path.arcTo(arcRect,
+			   cNet->interpolation == GERBV_INTERPOLATION_CW_CIRCULAR ? cNet->cirseg->angle2 : cNet->cirseg->angle1,
+			   fabs(ang2-ang1));
 }
 
 void gerbvQt::drawArcNet(const gerbv_net_t* cNet, const gerbv_aperture_t* ap) {
@@ -719,8 +719,8 @@ void gerbvQt::generatePareaPolygon(QPainterPath& path, const gerbv_net_t* startN
 				break;
 			case GERBV_INTERPOLATION_CW_CIRCULAR:
 			case GERBV_INTERPOLATION_CCW_CIRCULAR:
-				path.lineTo(point); //Mhm. Is it right? O_o
 				this->generateArcPath(path, cNet);
+				path.lineTo(point);
 				break;
 			case GERBV_INTERPOLATION_PAREA_END :
 				path.closeSubpath();


### PR DESCRIPTION
Hey @sx107 

I have used your tool and found some troubles with the polygons containing arcs:
![test](https://user-images.githubusercontent.com/1609182/66124251-3110ce80-e5e4-11e9-8492-c999197c8e97.png)

While with cairo:
![cairo](https://user-images.githubusercontent.com/1609182/66124260-3706af80-e5e4-11e9-802d-231a69169902.png)

And this is how gerbv shows it:
![kép](https://user-images.githubusercontent.com/1609182/66124285-4554cb80-e5e4-11e9-99d6-bafd1758d318.png)

The following patch solves this arc drawing issue.

This fix also replaces ceil calls with qCeil providing more portable solution.